### PR TITLE
With stats logs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "keywords": ["Docker", "container", "ReactPHP", "async"],
     "homepage": "https://github.com/clue/php-docker-react",
     "license": "MIT",
+    "version": "0.2.1",
     "authors": [
         {
             "name": "Christian Lück",

--- a/src/Client.php
+++ b/src/Client.php
@@ -562,7 +562,7 @@ class Client
                     'stderr' => $this->boolArg($stderr),
                     'since' => $since,
                     'timestamps' => $this->boolArg($timestamps),
-                    'tail' => $tail,
+                    'tail' => $tail
                 )
             )
         )->then(array($this->parser, 'expectPlain'));

--- a/src/Client.php
+++ b/src/Client.php
@@ -519,8 +519,8 @@ class Client
     /**
      * Retrieve container resource usage stats
      *
-     * @param string      $container container ID
-     * @param boolean     $stream
+     * @param string      $container    container ID
+     * @param boolean     $stream       return stream
      * @return Promise Promise<array>
      * @link https://docs.docker.com/reference/api/docker_remote_api_v1.20/#get-container-stats-based-on-resource-usage
      */
@@ -541,12 +541,12 @@ class Client
      * Retrieve container logs
      *
      * @param string      $container    container ID
-     * @param boolean     $follow       Return stream
-     * @param boolean     $stdout       Show stdout log.
-     * @param boolean     $stderr       Show stderr log.
+     * @param boolean     $follow       return stream
+     * @param boolean     $stdout       show stdout log.
+     * @param boolean     $stderr       show stderr log.
      * @param integer     $since        UNIX timestamp to filter logs. Specifying a timestamp will only output log-entries since that timestamp.
-     * @param boolean     $timestamps   Include timestamps
-     * @param integer     $tail         Output specified number of lines at the end of logs
+     * @param boolean     $timestamps   include timestamps
+     * @param integer     $tail         output specified number of lines at the end of logs
      * @return Promise Promise<string>
      * @link https://docs.docker.com/reference/api/docker_remote_api_v1.20/#get-container-logs
      */
@@ -567,7 +567,7 @@ class Client
             )
         )->then(array($this->parser, 'expectPlain'));
     }
-    
+
     /**
      * List images
      *

--- a/src/Client.php
+++ b/src/Client.php
@@ -517,6 +517,58 @@ class Client
     }
 
     /**
+     * Retrieve container resource usage stats
+     *
+     * @param string      $container container ID
+     * @param boolean     $stream
+     * @return Promise Promise<array>
+     * @link https://docs.docker.com/reference/api/docker_remote_api_v1.20/#get-container-stats-based-on-resource-usage
+     */
+    public function containerStats($container, $stream = false)
+    {
+        return $this->browser->get(
+            $this->browser->resolve(
+                '/containers/{container}/stats{?stream}',
+                array(
+                    'container' => $container,
+                    'stream' => $stream ? 1 : 0
+                )
+            )
+        )->then(array($this->parser, 'expectJson'));
+    }
+
+    /**
+     * Retrieve container logs
+     *
+     * @param string      $container    container ID
+     * @param boolean     $follow       Return stream
+     * @param boolean     $stdout       Show stdout log.
+     * @param boolean     $stderr       Show stderr log.
+     * @param integer     $since        UNIX timestamp to filter logs. Specifying a timestamp will only output log-entries since that timestamp.
+     * @param boolean     $timestamps   Include timestamps
+     * @param integer     $tail         Output specified number of lines at the end of logs
+     * @return Promise Promise<string>
+     * @link https://docs.docker.com/reference/api/docker_remote_api_v1.20/#get-container-logs
+     */
+    public function containerLogs($container, $follow = false, $stdout = true, $stderr = true, $since = 0, $timestamps = false, $tail = 'all')
+    {
+        return $this->browser->get(
+            $this->browser->resolve(
+                '/containers/{container}/logs{?follow,stdout,stderr,since,timestamps,tail}',
+                array(
+                    'container' => $container,
+                    'follow' => $this->boolArg($follow),
+                    'stdout' => $this->boolArg($stdout),
+                    'stderr' => $this->boolArg($stderr),
+                    'since' => $since,
+                    'timestamps' => $this->boolArg($timestamps),
+                    'tail' => $tail,
+                )
+            )
+        )->then(array($this->parser, 'expectPlain'));
+    }
+    
+    /**
      * List images
      *
      * @param boolean $all

--- a/src/Io/ResponseParser.php
+++ b/src/Io/ResponseParser.php
@@ -16,8 +16,7 @@ class ResponseParser
     public function expectJson(Response $response)
     {
         // application/json
-
-        return json_decode((string)$response->getBody(), true, 512, JSON_BIGINT_AS_STRING);
+        return @json_decode((string)$response->getBody(), true, 512, JSON_BIGINT_AS_STRING);
     }
 
     public function expectEmpty(Response $response)

--- a/src/Io/ResponseParser.php
+++ b/src/Io/ResponseParser.php
@@ -17,7 +17,7 @@ class ResponseParser
     {
         // application/json
 
-        return json_decode((string)$response->getBody(), true);
+        return json_decode((string)$response->getBody(), true, 512, JSON_BIGINT_AS_STRING);
     }
 
     public function expectEmpty(Response $response)


### PR DESCRIPTION
No tests included, but I've tested it a bit in my application and seems to work.

I didn't use your `Client::boolArg` helper for the stats argument `$stream` because the default in Docker API 1.20 is true so if you passed `false` it just would return `NULL` (and wouldn't be included in the request).
