### PR TITLE
Update all ReactPHP dependencies to latest versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,19 @@
     },
     "require": {
         "php": ">=5.3",
-        "clue/buzz-react": "^1.0",
+        "clue/buzz-react": "^2.0",
         "clue/json-stream": "^0.1",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
         "react/promise": "^2.0 || ^1.1",
         "react/promise-stream": "^1.0",
+        "react/socket": "^1.0",
+        "react/stream": "^1.0",
         "rize/uri-template": "^0.3"
     },
     "require-dev": {
         "clue/block-react": "^1.0 || ^0.3",
         "clue/caret-notation": "^0.2",
-        "clue/tar-react": "^0.2 || ^0.1",
+        "clue/tar-react": "^0.2",
         "phpunit/phpunit": "^7.0 || ^6.0 || ^5.0 || ^4.8.35"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,17 @@
     },
     "require": {
         "php": ">=5.3",
-        "react/event-loop": "~0.3.0|~0.4.0",
-        "clue/buzz-react": "^0.5",
-        "react/promise": "~2.0|~1.1",
-        "clue/json-stream": "~0.1.0",
-        "rize/uri-template": "^0.3",
-        "clue/promise-stream-react": "^0.1"
+        "clue/buzz-react": "^1.0",
+        "clue/json-stream": "^0.1",
+        "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
+        "react/promise": "^2.0 || ^1.1",
+        "react/promise-stream": "^1.0",
+        "rize/uri-template": "^0.3"
     },
     "require-dev": {
-        "clue/block-react": "~0.3.0",
-        "clue/caret-notation": "~0.2.0",
-        "clue/tar-react": "~0.1.0",
+        "clue/block-react": "^1.0 || ^0.3",
+        "clue/caret-notation": "^0.2",
+        "clue/tar-react": "^0.2 || ^0.1",
         "phpunit/phpunit": "^7.0 || ^6.0 || ^5.0 || ^4.8.35"
     }
 }

--- a/examples/exec-stream.php
+++ b/examples/exec-stream.php
@@ -4,9 +4,13 @@
 // displays the streaming output as it happens.
 
 use Clue\React\Docker\Client;
-use React\Stream\Stream;
+use React\Stream\WritableResourceStream;
 
 require __DIR__ . '/../vendor/autoload.php';
+
+if (DIRECTORY_SEPARATOR === '\\') {
+    exit('File I/O not supported on Windows' . PHP_EOL);
+}
 
 $container = 'asd';
 //$cmd = array('echo', 'hello world');
@@ -22,11 +26,8 @@ if (isset($argv[1])) {
 $loop = React\EventLoop\Factory::create();
 $client = new Client($loop);
 
-$out = new Stream(STDOUT, $loop);
-$out->pause();
-
-$stderr = new Stream(STDERR, $loop);
-$stderr->pause();
+$out = new WritableResourceStream(STDOUT, $loop);
+$stderr = new WritableResourceStream(STDERR, $loop);
 
 // unkown exit code by default
 $exit = 1;

--- a/examples/export.php
+++ b/examples/export.php
@@ -4,9 +4,13 @@
 // and how we it can be piped into a output tar file.
 
 use Clue\React\Docker\Client;
-use React\Stream\Stream;
+use React\Stream\WritableResourceStream;
 
 require __DIR__ . '/../vendor/autoload.php';
+
+if (DIRECTORY_SEPARATOR === '\\') {
+    exit('File I/O not supported on Windows' . PHP_EOL);
+}
 
 $container = isset($argv[1]) ? $argv[1] : 'asd';
 $target = isset($argv[2]) ? $argv[2] : ($container . '.tar');
@@ -22,8 +26,7 @@ $stream->on('error', function ($e = null) {
     echo 'ERROR requesting stream' . PHP_EOL . $e;
 });
 
-$out = new Stream(fopen($target, 'w'), $loop);
-$out->pause();
+$out = new WritableResourceStream(fopen($target, 'w'), $loop);
 $stream->pipe($out);
 
 $loop->run();

--- a/src/Client.php
+++ b/src/Client.php
@@ -42,11 +42,13 @@ class Client
 
         if (substr($url, 0, 7) === 'unix://') {
             // send everything through a local unix domain socket
-            $browser = $browser->withSender(
-                Sender::createFromLoopUnix($loop, $url)
+            $connector = new \React\Socket\FixedUriConnector(
+                $url,
+                new \React\Socket\UnixConnector($loop)
             );
 
             // pretend all HTTP URLs to be on localhost
+            $browser = new Browser($loop, $connector);
             $url = 'http://localhost/';
         }
 

--- a/src/Io/StreamingParser.php
+++ b/src/Io/StreamingParser.php
@@ -2,10 +2,10 @@
 
 namespace Clue\React\Docker\Io;
 
-use Clue\React\Promise\Stream;
 use Psr\Http\Message\ResponseInterface;
-use React\Promise\PromiseInterface;
 use React\Promise\Deferred;
+use React\Promise\PromiseInterface;
+use React\Promise\Stream;
 use React\Stream\ReadableStreamInterface;
 use RuntimeException;
 

--- a/tests/FunctionalClientTest.php
+++ b/tests/FunctionalClientTest.php
@@ -4,8 +4,8 @@ namespace Clue\Tests\React\Docker;
 
 use Clue\React\Block;
 use Clue\React\Docker\Client;
-use Clue\React\Promise\Stream;
 use React\EventLoop\Factory as LoopFactory;
+use React\Promise\Stream;
 
 class FunctionalClientTest extends TestCase
 {

--- a/tests/Io/ReadableDemultiplexStreamTest.php
+++ b/tests/Io/ReadableDemultiplexStreamTest.php
@@ -4,8 +4,7 @@ namespace Clue\Tests\React\Docker\Io;
 
 use Clue\React\Docker\Io\ReadableDemultiplexStream;
 use Clue\Tests\React\Docker\TestCase;
-use React\Stream\ReadableStream;
-use React\Stream\WritableStream;
+use React\Stream\ThroughStream;
 
 class ReadableDemultiplexStreamTest extends TestCase
 {
@@ -14,7 +13,7 @@ class ReadableDemultiplexStreamTest extends TestCase
 
     public function setUp()
     {
-        $this->stream = new ReadableStream();
+        $this->stream = new ThroughStream();
         $this->parser = new ReadableDemultiplexStream($this->stream);
     }
 
@@ -106,7 +105,7 @@ class ReadableDemultiplexStreamTest extends TestCase
 
     public function testPipeWillBeForwardedToTargetStream()
     {
-        $target = new WritableStream();
+        $target = new ThroughStream();
         $target->on('pipe', $this->expectCallableOnceWith($this->parser));
 
         $this->parser->pipe($target);

--- a/tests/Io/ReadableJsonStreamTest.php
+++ b/tests/Io/ReadableJsonStreamTest.php
@@ -4,8 +4,7 @@ namespace Clue\Tests\React\Docker\Io;
 
 use Clue\React\Docker\Io\ReadableJsonStream;
 use Clue\Tests\React\Docker\TestCase;
-use React\Stream\ReadableStream;
-use React\Stream\WritableStream;
+use React\Stream\ThroughStream;
 
 class ReadableJsonStreamTest extends TestCase
 {
@@ -14,7 +13,7 @@ class ReadableJsonStreamTest extends TestCase
 
     public function setUp()
     {
-        $this->stream = new ReadableStream();
+        $this->stream = new ThroughStream();
         $this->parser = new ReadableJsonStream($this->stream);
     }
 
@@ -129,7 +128,7 @@ class ReadableJsonStreamTest extends TestCase
 
     public function testPipeWillBeForwardedToTargetStream()
     {
-        $target = new WritableStream();
+        $target = new ThroughStream();
         $target->on('pipe', $this->expectCallableOnceWith($this->parser));
 
         $this->parser->pipe($target);

--- a/tests/Io/StreamingParserTest.php
+++ b/tests/Io/StreamingParserTest.php
@@ -20,7 +20,7 @@ class StreamingParserTest extends TestCase
 
     public function testJsonPassingRejectedPromiseResolvesWithClosedStream()
     {
-        $stream = $this->parser->parseJsonStream(Promise\reject());
+        $stream = $this->parser->parseJsonStream(Promise\reject(new \RuntimeException()));
 
         $this->assertInstanceOf('React\Stream\ReadableStreamInterface', $stream);
         $this->assertFalse($stream->isReadable());
@@ -62,7 +62,7 @@ class StreamingParserTest extends TestCase
 
     public function testPlainPassingRejectedPromiseResolvesWithClosedStream()
     {
-        $stream = $this->parser->parsePlainStream(Promise\reject());
+        $stream = $this->parser->parsePlainStream(Promise\reject(new \RuntimeException()));
 
         $this->assertInstanceOf('React\Stream\ReadableStreamInterface', $stream);
         $this->assertFalse($stream->isReadable());
@@ -102,12 +102,12 @@ class StreamingParserTest extends TestCase
 
         $stream->emit('data', array('a'));
 
-        $stream->emit('error', array('value', 'ignord'));
+        $stream->emit('error', array(new \RuntimeException()));
 
         $stream->close();
 
         $this->expectPromiseReject($promise);
-        $promise->then(null, $this->expectCallableOnceWith('value'));
+        $promise->then(null, $this->expectCallableOnceWith($this->isInstanceOf('RuntimeException')));
     }
 
     public function testDeferredCancelingPromiseWillCloseStream()

--- a/tests/Io/StreamingParserTest.php
+++ b/tests/Io/StreamingParserTest.php
@@ -7,7 +7,7 @@ use Clue\Tests\React\Docker\TestCase;
 use React\Promise;
 use React\Promise\CancellablePromiseInterface;
 use React\Promise\Deferred;
-use React\Stream\ReadableStream;
+use React\Stream\ThroughStream;
 
 class StreamingParserTest extends TestCase
 {
@@ -79,7 +79,7 @@ class StreamingParserTest extends TestCase
 
     public function testDeferredStreamEventsWillBeEmittedAndBuffered()
     {
-        $stream = new ReadableStream();
+        $stream = new ThroughStream();
 
         $promise = $this->parser->deferredStream($stream);
 
@@ -94,7 +94,7 @@ class StreamingParserTest extends TestCase
 
     public function testDeferredStreamErrorEventWillRejectPromise()
     {
-        $stream = new ReadableStream();
+        $stream = new ThroughStream();
 
         $promise = $this->parser->deferredStream($stream);
 
@@ -126,7 +126,7 @@ class StreamingParserTest extends TestCase
 
     public function testDemultiplexStreamWillReturnReadable()
     {
-        $stream = new ReadableStream();
+        $stream = new ThroughStream();
 
         $out = $this->parser->demultiplexStream($stream);
 


### PR DESCRIPTION
Among others, this also improves the benchmarking performance from ~1600 MiB/s to ~1800 MiB/s.

Builds on top of #49 and #50