### PR TITLE
Update benchmark output and results

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,14 +227,14 @@ See also the [streaming exec example](examples/exec-stream.php) and the [exec be
 The TTY mode should be set depending on whether your command needs a TTY
 or not. Note that toggling the TTY mode affects how/whether you can access
 the STDERR stream and also has a significant impact on performance for
-larger streams (relevant for 100 MiB and above). See also the TTY mode
-on the `execStart*()` call.
+larger streams (relevant for hundreds of megabytes and more). See also the TTY
+mode on the `execStart*()` call.
 
-Running this benchmark on my personal (rather mediocre) VM setup reveals that
-the benchmark achieves a throughput of ~300 MiB/s while the (totally unfair)
-comparison script using the plain Docker client only yields ~100 MiB/s.
-Instead of me posting more details here, I encourage you to re-run the benchmark
-yourself and adjust it to better suite your problem domain.
+Running the provided benchmark example on a range of systems, it suggests that
+this library can process several gigabytes per second and may in fact outperform
+the Docker client and seems to be limited only by the Docker Engine implementation.
+Instead of posting more details here, you're encouraged to re-run the benchmarks
+yourself and see for yourself.
 The key takeway here is: *PHP is faster than you probably thought*.
 
 #### TAR streaming

--- a/examples/benchmark-exec.php
+++ b/examples/benchmark-exec.php
@@ -1,8 +1,14 @@
 <?php
 
-// this simple example executes a command within the given running container and
+// This simple example executes a command within the given running container and
 // displays how fast it can receive its output.
-// expect this to be significantly faster than the (totally unfair) equivalent:
+//
+// Before starting the benchmark, you have to start a container first, such as:
+//
+// $ docker run -it --rm --name=asd busybox sh
+//
+// Expect this to be significantly faster than the (totally unfair) equivalent:
+//
 // $ docker exec asd dd if=/dev/zero bs=1M count=1000 | dd of=/dev/null
 
 use Clue\React\Docker\Client;
@@ -35,7 +41,7 @@ $client->execCreate($container, $cmd)->then(function ($info) use ($client) {
     $stream->on('close', function () use ($client, &$bytes, $start) {
         $time = microtime(true) - $start;
 
-        echo 'Received ' . $bytes . ' bytes in ' . round($time, 1) . 's => ' . round($bytes / $time / 1024 / 1024, 1) . ' MiB/s' . PHP_EOL;
+        echo 'Received ' . $bytes . ' bytes in ' . round($time, 1) . 's => ' . round($bytes / $time / 1000000, 1) . ' MB/s' . PHP_EOL;
     });
 }, 'printf');
 


### PR DESCRIPTION
For the reference, here's one of the latest runs on my laptop:

```
$ php examples/benchmark-exec.php asd dd if=/dev/zero bs=1M count=4k
Received 4294967296 bytes in 1.8s => 2355.1 MB/s
```