### PR TITLE
Add `containerAttach()` and `containerAttachStream()` API methods 

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ The following API endpoints resolve with a buffered string of the command output
 (STDOUT and/or STDERR):
 
 ```php
+$client->containerAttach($container);
 $client->containerLogs($container);
 $client->execStart($exec);
 ```
@@ -186,6 +187,7 @@ The following API endpoints complement the default Promise-based API and return
 a [`Stream`](https://github.com/reactphp/stream) instance instead:
 
 ```php
+$stream = $client->containerAttachStream($container);
 $stream = $client->containerLogsStream($container);
 $stream = $client->execStartStream($exec);
 ```

--- a/examples/attach-stream.php
+++ b/examples/attach-stream.php
@@ -1,0 +1,37 @@
+<?php
+
+// this example shows how the containerAttachStream() call can be used to get the output of the given container.
+// demonstrates the streaming attach API, which can be used to dump the container output as it arrives
+//
+// $ docker run -it --rm --name=foo busybox sh
+// $ php examples/attach-stream.php foo
+
+use Clue\CaretNotation\Encoder;
+use Clue\React\Docker\Client;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$container = isset($argv[1]) ? $argv[1] : 'foo';
+echo 'Dumping output of container "' . $container . '" (pass as argument to this example)' . PHP_EOL;
+
+$loop = React\EventLoop\Factory::create();
+$client = new Client($loop);
+
+// use caret notation for any control characters except \t, \r and \n
+$caret = new Encoder("\t\r\n");
+
+$stream = $client->containerAttachStream($container, true, true);
+$stream->on('data', function ($data) use ($caret) {
+    echo $caret->encode($data);
+});
+
+$stream->on('error', function (Exception $e) {
+    // will be called if either parameter is invalid
+    echo 'ERROR: ' . $e->getMessage() . PHP_EOL;
+});
+
+$stream->on('close', function () {
+    echo 'CLOSED' . PHP_EOL;
+});
+
+$loop->run();

--- a/examples/benchmark-attach.php
+++ b/examples/benchmark-attach.php
@@ -1,0 +1,66 @@
+<?php
+
+// This example executes a command within a new container and displays how fast
+// it can receive its output.
+//
+// $ php examples/benchmark-attach.php
+// $ php examples/benchmark-attach.php busybox echo -n hello
+//
+// Expect this to be noticeably faster than the (totally unfair) equivalent:
+//
+// $ docker run -i --rm --log-driver=none busybox dd if=/dev/zero bs=1M count=1000 status=none | dd of=/dev/null
+
+use Clue\React\Docker\Client;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+if (extension_loaded('xdebug')) {
+    echo 'NOTICE: The "xdebug" extension is loaded, this has a major impact on performance.' . PHP_EOL;
+}
+
+$image = 'busybox';
+$cmd = array('dd', 'if=/dev/zero', 'bs=1M', 'count=1000', 'status=none');
+
+if (isset($argv[1])) {
+    $image = $argv[1];
+    $cmd = array_slice($argv, 2);
+}
+
+$loop = React\EventLoop\Factory::create();
+$client = new Client($loop);
+
+$client->containerCreate(array(
+    'Image' => $image,
+    'Cmd' => $cmd,
+    'Tty' => false,
+    'HostConfig' => array(
+        'LogConfig' => array(
+            'Type' => 'none'
+        )
+    )
+))->then(function ($container) use ($client, $loop) {
+    $stream = $client->containerAttachStream($container['Id'], false, true);
+
+    // we're creating the container without a log, so first wait for attach stream before starting
+    $loop->addTimer(0.1, function () use ($client, $container) {
+        $client->containerStart($container['Id'])->then(null, 'printf');
+    });
+
+    $start = microtime(true);
+    $bytes = 0;
+    $stream->on('data', function ($chunk) use (&$bytes) {
+        $bytes += strlen($chunk);
+    });
+
+    $stream->on('error', 'printf');
+
+    // show stats when stream ends
+    $stream->on('close', function () use ($client, &$bytes, $start, $container) {
+        $time = microtime(true) - $start;
+        $client->containerRemove($container['Id'])->then(null, 'printf');
+
+        echo 'Received ' . $bytes . ' bytes in ' . round($time, 1) . 's => ' . round($bytes / $time / 1000000, 1) . ' MB/s' . PHP_EOL;
+    });
+}, 'printf');
+
+$loop->run();

--- a/examples/benchmark-exec.php
+++ b/examples/benchmark-exec.php
@@ -1,21 +1,27 @@
 <?php
 
-// This simple example executes a command within the given running container and
+// This example executes a command within the given running container and
 // displays how fast it can receive its output.
 //
 // Before starting the benchmark, you have to start a container first, such as:
 //
-// $ docker run -it --rm --name=asd busybox sh
+// $ docker run -it --rm --name=foo busybox sh
+// $ php examples/benchmark-exec.php
+// $ php examples/benchmark-exec.php foo echo -n hello
 //
 // Expect this to be significantly faster than the (totally unfair) equivalent:
 //
-// $ docker exec asd dd if=/dev/zero bs=1M count=1000 | dd of=/dev/null
+// $ docker exec foo dd if=/dev/zero bs=1M count=1000 | dd of=/dev/null
 
 use Clue\React\Docker\Client;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$container = 'asd';
+if (extension_loaded('xdebug')) {
+    echo 'NOTICE: The "xdebug" extension is loaded, this has a major impact on performance.' . PHP_EOL;
+}
+
+$container = 'foo';
 $cmd = array('dd', 'if=/dev/zero', 'bs=1M', 'count=1000');
 
 if (isset($argv[1])) {

--- a/examples/logs.php
+++ b/examples/logs.php
@@ -2,13 +2,17 @@
 
 // this example shows how the containerLogs() call can be used to get the logs of the given container.
 // demonstrates the deferred logs API, which can be used to dump the logs in one go
+//
+// $ docker run -d --name=foo busybox ps
+// $ php examples/logs.php foo
+// $ docker rm foo
 
 use Clue\CaretNotation\Encoder;
 use Clue\React\Docker\Client;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$container = isset($argv[1]) ? $argv[1] : 'asd';
+$container = isset($argv[1]) ? $argv[1] : 'foo';
 echo 'Dumping logs (last 100 lines) of container "' . $container . '" (pass as argument to this example)' . PHP_EOL;
 
 $loop = React\EventLoop\Factory::create();

--- a/tests/FunctionalClientTest.php
+++ b/tests/FunctionalClientTest.php
@@ -74,6 +74,11 @@ class FunctionalClientTest extends TestCase
 
         $this->assertEquals("test\n", $ret);
 
+        $promise = $this->client->containerAttach($container['Id'], true, false);
+        $ret = Block\await($promise, $this->loop);
+
+        $this->assertEquals("test\n", $ret);
+
         $promise = $this->client->containerRemove($container['Id'], false, true);
         $ret = Block\await($promise, $this->loop);
 
@@ -85,12 +90,13 @@ class FunctionalClientTest extends TestCase
         $promise = $this->client->events($start, $end, array('container' => array($container['Id'])));
         $ret = Block\await($promise, $this->loop);
 
-        // expects "start", "kill", "die", "destroy" events
-        $this->assertEquals(4, count($ret));
+        // expects "start", "attach", "kill", "die", "destroy" events
+        $this->assertEquals(5, count($ret));
         $this->assertEquals('start', $ret[0]['status']);
-        $this->assertEquals('kill', $ret[1]['status']);
-        $this->assertEquals('die', $ret[2]['status']);
-        $this->assertEquals('destroy', $ret[3]['status']);
+        $this->assertEquals('attach', $ret[1]['status']);
+        $this->assertEquals('kill', $ret[2]['status']);
+        $this->assertEquals('die', $ret[3]['status']);
+        $this->assertEquals('destroy', $ret[4]['status']);
     }
 
     /**


### PR DESCRIPTION
For the reference, here's one of the latest runs on my laptop:

```
$ php examples/benchmark-attach.php busybox dd if=/dev/zero bs=1M count=4k status=none
Received 4294967296 bytes in 4.6s => 935.5 MB/s
```

Resolves / closes #13 
Builds on top of #56 and #60 
Refs #33 for future API to expose `STDIN` stream.