### PR TITLE
Adds Support for TCP Hijack in execStartStream

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,6 @@
     "keywords": ["Docker", "container", "ReactPHP", "async"],
     "homepage": "https://github.com/clue/reactphp-docker",
     "license": "MIT",
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "authors": [
         {
             "name": "Christian Lück",
@@ -20,7 +18,7 @@
     },
     "require": {
         "php": ">=5.3",
-        "react/http": "dev-writable",
+        "clue/buzz-react": "^2.0",
         "clue/json-stream": "^0.1",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
         "react/promise": "^2.0 || ^1.1",
@@ -34,14 +32,5 @@
         "clue/caret-notation": "^0.2",
         "clue/tar-react": "^0.2",
         "phpunit/phpunit": "^7.0 || ^6.0 || ^5.0 || ^4.8.35"
-    },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "/Users/mac/Projects/oss/http",
-            "options": {
-                "symlink": true
-            }
-        }
-    ]
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,8 @@
     "keywords": ["Docker", "container", "ReactPHP", "async"],
     "homepage": "https://github.com/clue/reactphp-docker",
     "license": "MIT",
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "authors": [
         {
             "name": "Christian Lück",
@@ -18,7 +20,7 @@
     },
     "require": {
         "php": ">=5.3",
-        "react/http": "dev-master",
+        "react/http": "dev-writable",
         "clue/json-stream": "^0.1",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
         "react/promise": "^2.0 || ^1.1",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": ">=5.3",
-        "clue/buzz-react": "^2.0",
+        "react/http": "dev-master",
         "clue/json-stream": "^0.1",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
         "react/promise": "^2.0 || ^1.1",
@@ -32,5 +32,14 @@
         "clue/caret-notation": "^0.2",
         "clue/tar-react": "^0.2",
         "phpunit/phpunit": "^7.0 || ^6.0 || ^5.0 || ^4.8.35"
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "/Users/mac/Projects/oss/http",
+            "options": {
+                "symlink": true
+            }
+        }
+    ]
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,7 +2,7 @@
 
 namespace Clue\React\Docker;
 
-use Clue\React\Buzz\Browser;
+use React\Http\Browser;
 use Clue\React\Docker\Io\ResponseParser;
 use Clue\React\Docker\Io\StreamingParser;
 use React\EventLoop\LoopInterface;

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,7 +2,7 @@
 
 namespace Clue\React\Docker;
 
-use React\Http\Browser;
+use Clue\React\Buzz\Browser;
 use Clue\React\Docker\Io\ResponseParser;
 use Clue\React\Docker\Io\StreamingParser;
 use React\EventLoop\LoopInterface;

--- a/src/Client.php
+++ b/src/Client.php
@@ -1302,7 +1302,7 @@ class Client
      * @see self::execStart()
      * @see self::execStartDetached()
      */
-    public function execStartStream($exec, $tty = false, $hijack = false, $stderrEvent = null)
+    public function execStartStream($exec, $tty = false, $stderrEvent = null, $hijack = false)
     {
         if ($hijack) {
             return $this->execStartStreamUpgrade($exec, $stderrEvent);

--- a/src/Client.php
+++ b/src/Client.php
@@ -1333,10 +1333,9 @@ class Client
         return $stream;
     }
 
-    protected function execStartStreamUpgrade($exec, $stderrEvent = null)
+    protected function execStartStreamUpgrade($exec, $tty = false)
     {
-        return $this->browser->withOptions(array('streaming' => true, 'hijack' => true))->requestUpgrade(
-            "POST",
+        return $this->browser->withOptions(array('streaming' => true, 'upgrade' => true))->post(
             $this->uri->expand(
                 '/exec/{exec}/start',
                 array(
@@ -1349,7 +1348,7 @@ class Client
                 'Upgrade' => 'tcp',
             ),
             $this->json(array(
-                'Tty' => true
+                'Tty' => !!$tty
             ))
         );
     }


### PR DESCRIPTION
- Expected to fix #33 
- As suggested in the Docker API documentation on https://docs.docker.com/engine/api/v1.24/#42-hijacking
- Depends on https://github.com/reactphp/http/pull/382 (Not sure how `clue/reactphp-buzz` comes to play)

## Summary of changes
- Adds `$hijak` parameter to `exectStartsStream`
- Configures the browser based on `$hijak`

Example Usage
```php
$client->execCreate('bash', 'bash', true, true, true, true)
            ->then(function($info) use ($client) {
                $client->execStartStream($info['Id'], true,'stderr', true)->then(function (UpgradedResponse $e) use ($deferred) {
                    $stream = $e->getConnection();
                    $stream->on('data', function ($chunk) {
                        echo $chunk;
                    });

                    $stream->write("ls\r"); // list directories
                });
            });
```