### PR TITLE
Update tests to close any server sockets

### DIFF
--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -38,6 +38,8 @@ class IntegrationTest extends TestCase
         unlink($path);
 
         $this->assertEquals('/_ping', $value);
+
+        $socket->close();
     }
 
     public function testPingCtorWithExplicitHttpUrlSendsRequestToGivenHttpUrlWithBase()
@@ -58,5 +60,7 @@ class IntegrationTest extends TestCase
         $value = \Clue\React\Block\await($deferred->promise(), $loop, 1.0);
 
         $this->assertEquals('/base/_ping', $value);
+
+        $socket->close();
     }
 }


### PR DESCRIPTION
Close open connections in tests to prevent them from looping in the async update.

Based on https://github.com/reactphp/socket/pull/283

Ref: https://github.com/clue/reactphp-docker/pull/77