### PR TITLE
Update test suite to ensure 100% code coverage across Promise v3/v2/v1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "clue/json-stream": "^0.1",
         "react/event-loop": "^1.2",
         "react/http": "^1.8",
-        "react/promise": "^3 || ^2.0 || ^1.1",
+        "react/promise": "^3.1 || ^2.11 || ^1.3",
         "react/promise-stream": "^1.6",
         "react/socket": "^1.12",
         "react/stream": "^1.2",

--- a/tests/Io/StreamingParserTest.php
+++ b/tests/Io/StreamingParserTest.php
@@ -5,7 +5,6 @@ namespace Clue\Tests\React\Docker\Io;
 use Clue\React\Docker\Io\StreamingParser;
 use Clue\Tests\React\Docker\TestCase;
 use React\Promise;
-use React\Promise\CancellablePromiseInterface;
 use React\Promise\Deferred;
 use React\Stream\ThroughStream;
 
@@ -119,11 +118,10 @@ class StreamingParserTest extends TestCase
         $stream->expects($this->once())->method('isReadable')->willReturn(true);
 
         $promise = $this->parser->deferredStream($stream);
-        if (!($promise instanceof CancellablePromiseInterface)) {
-            $this->markTestSkipped('Requires Promise v2 API and has no effect on v1 API');
-        }
 
         $stream->expects($this->once())->method('close');
+
+        assert(method_exists($promise, 'cancel'));
         $promise->cancel();
     }
 


### PR DESCRIPTION
This changeset updates the test suite to ensure 100% code coverage across Promise v3/v2/v1. This needs to bump promise versions to include https://github.com/reactphp/promise/pull/20 and https://github.com/reactphp/promise/pull/48, so I went for the latest versions while I'm at it.

Builds on top of #81 and #76