### PR TITLE
Run tests on PHP 8.3 and update test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.3
           - 8.2
           - 8.1
           - 8.0
@@ -24,7 +25,7 @@ jobs:
           - 5.4
           - 5.3
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "clue/caret-notation": "^0.2",
         "clue/tar-react": "^0.2",
-        "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35",
+        "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
         "react/async": "^4 || ^3 || ^2"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- PHPUnit configuration file with new format for PHPUnit 9.5+ -->
+<!-- PHPUnit configuration file with new format for PHPUnit 9.6+ -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          cacheResult="false"
          colors="true"


### PR DESCRIPTION
This pull request builds on top of #80, #82, #83, #84 and #78.

References: https://github.com/reactphp/socket/pull/300, https://github.com/clue/reactphp-zenity/pull/63, https://github.com/clue/reactphp-csv/pull/33, https://github.com/reactphp/promise-stream/pull/39 and others.

After https://github.com/clue/reactphp-docker/pull/83 was merged, I could go on with this pull request, thanks to @clue and @SimonFrings.