### PR TITLE
Update test suite to support new reactphp/http `v1.10.0`

### DIFF
--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -4,9 +4,9 @@ namespace Clue\Tests\React\Docker;
 
 use Clue\React\Docker\Client;
 use Psr\Http\Message\ResponseInterface;
+use React\Http\Message\Response;
 use React\Promise\Deferred;
 use React\Stream\ThroughStream;
-use RingCentral\Psr7\Response;
 
 class ClientTest extends TestCase
 {

--- a/tests/Io/ResponseParserTest.php
+++ b/tests/Io/ResponseParserTest.php
@@ -4,7 +4,7 @@ namespace Clue\Tests\React\Docker\Io;
 
 use Clue\React\Docker\Io\ResponseParser;
 use Clue\Tests\React\Docker\TestCase;
-use RingCentral\Psr7\Response;
+use React\Http\Message\Response;
 
 class ResponseParserTest extends TestCase
 {


### PR DESCRIPTION
This changeset updates the test suite to support [reactphp/http `v1.10.0`](https://github.com/reactphp/http/releases/tag/v1.10.0). This new version of the ReactPHP HTTP component introduces its own PSR-7 implementation and removes the dependency for RingCentral (see https://github.com/reactphp/http/pull/522 for reference). This means we don't have to rely on the RingCentral dependency here as well, and instead can use ReactPHP's new PSR-7 implementation.

Builds on top of #76 and others