### PR TITLE
Improve PHP 8.4+ support by avoiding implicitly nullable types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,18 +14,18 @@
         "php": ">=5.3",
         "clue/json-stream": "^0.1",
         "react/event-loop": "^1.2",
-        "react/http": "^1.8",
-        "react/promise": "^3.1 || ^2.11 || ^1.3",
+        "react/http": "^1.11",
+        "react/promise": "^3.2 || ^2.11 || ^1.3",
         "react/promise-stream": "^1.6",
-        "react/socket": "^1.12",
-        "react/stream": "^1.2",
+        "react/socket": "^1.16",
+        "react/stream": "^1.4",
         "rize/uri-template": "^0.3"
     },
     "require-dev": {
         "clue/caret-notation": "^0.2",
         "clue/tar-react": "^0.2",
         "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
-        "react/async": "^4 || ^3 || ^2"
+        "react/async": "^4.2 || ^3 || ^2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -56,8 +56,12 @@ class Client
      * @param ?string        $url
      * @throws \InvalidArgumentException
      */
-    public function __construct(LoopInterface $loop = null, $url = null)
+    public function __construct($loop = null, $url = null)
     {
+        if ($loop !== null && !$loop instanceof LoopInterface) { // manual type check to support legacy PHP < 7.1
+            throw new \InvalidArgumentException('Argument #1 ($loop) expected null|React\EventLoop\LoopInterface');
+        }
+
         if ($url === null) {
             $url = 'unix:///var/run/docker.sock';
         }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -59,6 +59,12 @@ class ClientTest extends TestCase
         new Client($loop);
     }
 
+    public function testCtorThrowsForInvalidLoop()
+    {
+        $this->setExpectedException('InvalidArgumentException', 'Argument #1 ($loop) expected null|React\EventLoop\LoopInterface');
+        new Client('loop');
+    }
+
     public function testCtorWithInvalidUrlThrows()
     {
         $this->setExpectedException('InvalidArgumentException');


### PR DESCRIPTION
This changeset improves PHP 8.4+ support by avoiding implicitly nullable types as discussed in https://github.com/reactphp/promise/pull/260. The same idea applies, but v1 requires manual type checks to support legacy PHP versions as the nullable type syntax requires PHP 7.1+ otherwise.

Builds on top of #85, https://github.com/reactphp/promise/pull/260, https://github.com/reactphp/stream/pull/179, https://github.com/reactphp/socket/pull/318, https://github.com/reactphp/http/pull/537 and https://github.com/reactphp/async/pull/87
Refs https://github.com/rize/UriTemplate/issues/29