### PR TITLE
Ubuntu 24.04 and update test enviroment + PCOV to avoid segfault with Xdebug 3.4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,11 @@ on:
 jobs:
   PHPUnit:
     name: PHPUnit (PHP ${{ matrix.php }})
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         php:
+          - 8.4
           - 8.3
           - 8.2
           - 8.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         php:
-          - 8.4
           - 8.3
           - 8.2
           - 8.1
@@ -30,7 +29,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          coverage: xdebug
+          coverage: ${{ matrix.php < 8.0 && 'xdebug' || 'pcov' }}
           ini-file: development
       - run: composer install
       - run: docker pull busybox:latest

--- a/composer.json
+++ b/composer.json
@@ -1,40 +1,44 @@
 {
-    "name": "clue/docker-react",
-    "description": "Async, event-driven access to the Docker Engine API, built on top of ReactPHP.",
-    "keywords": ["Docker", "container", "ReactPHP", "async"],
-    "homepage": "https://github.com/clue/reactphp-docker",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Christian Lück",
-            "email": "christian@clue.engineering"
-        }
-    ],
-    "require": {
-        "php": ">=5.3",
-        "clue/json-stream": "^0.1",
-        "react/event-loop": "^1.2",
-        "react/http": "^1.11",
-        "react/promise": "^3.2 || ^2.11 || ^1.3",
-        "react/promise-stream": "^1.6",
-        "react/socket": "^1.16",
-        "react/stream": "^1.4",
-        "rize/uri-template": "^0.3"
-    },
-    "require-dev": {
-        "clue/caret-notation": "^0.2",
-        "clue/tar-react": "^0.2",
-        "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
-        "react/async": "^4.2 || ^3 || ^2"
-    },
-    "autoload": {
-        "psr-4": {
-            "Clue\\React\\Docker\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Clue\\Tests\\React\\Docker\\": "tests/"
-        }
-    }
+	"name" : "clue/docker-react",
+	"description" : "Async, event-driven access to the Docker Engine API, built on top of ReactPHP.",
+	"keywords" : [
+		"Docker",
+		"container",
+		"ReactPHP",
+		"async"
+	],
+	"homepage" : "https://github.com/clue/reactphp-docker",
+	"license" : "MIT",
+	"authors" : [{
+			"name" : "Christian Lück",
+			"email" : "christian@clue.engineering"
+		}
+	],
+	"require" : {
+		"php" : ">=5.3",
+		"clue/json-stream" : "^0.1",
+		"react/event-loop" : "^1.2",
+		"react/http" : "^1.11",
+		"react/promise" : "^3.2 || ^2.11 || ^1.3",
+		"react/promise-stream" : "^1.6",
+		"react/socket" : "^1.16",
+		"react/stream" : "^1.4",
+		"rize/uri-template" : "^0.4"
+	},
+	"require-dev" : {
+		"clue/caret-notation" : "^0.2",
+		"clue/tar-react" : "^0.2",
+		"phpunit/phpunit" : "^9.6 || ^5.7 || ^4.8.36",
+		"react/async" : "^4.2 || ^3 || ^2"
+	},
+	"autoload" : {
+		"psr-4" : {
+			"Clue\\React\\Docker\\" : "src/"
+		}
+	},
+	"autoload-dev" : {
+		"psr-4" : {
+			"Clue\\Tests\\React\\Docker\\" : "tests/"
+		}
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -1,44 +1,40 @@
 {
-	"name" : "clue/docker-react",
-	"description" : "Async, event-driven access to the Docker Engine API, built on top of ReactPHP.",
-	"keywords" : [
-		"Docker",
-		"container",
-		"ReactPHP",
-		"async"
-	],
-	"homepage" : "https://github.com/clue/reactphp-docker",
-	"license" : "MIT",
-	"authors" : [{
-			"name" : "Christian Lück",
-			"email" : "christian@clue.engineering"
-		}
-	],
-	"require" : {
-		"php" : ">=5.3",
-		"clue/json-stream" : "^0.1",
-		"react/event-loop" : "^1.2",
-		"react/http" : "^1.11",
-		"react/promise" : "^3.2 || ^2.11 || ^1.3",
-		"react/promise-stream" : "^1.6",
-		"react/socket" : "^1.16",
-		"react/stream" : "^1.4",
-		"rize/uri-template" : "^0.4"
-	},
-	"require-dev" : {
-		"clue/caret-notation" : "^0.2",
-		"clue/tar-react" : "^0.2",
-		"phpunit/phpunit" : "^9.6 || ^5.7 || ^4.8.36",
-		"react/async" : "^4.2 || ^3 || ^2"
-	},
-	"autoload" : {
-		"psr-4" : {
-			"Clue\\React\\Docker\\" : "src/"
-		}
-	},
-	"autoload-dev" : {
-		"psr-4" : {
-			"Clue\\Tests\\React\\Docker\\" : "tests/"
-		}
-	}
+    "name": "clue/docker-react",
+    "description": "Async, event-driven access to the Docker Engine API, built on top of ReactPHP.",
+    "keywords": ["Docker", "container", "ReactPHP", "async"],
+    "homepage": "https://github.com/clue/reactphp-docker",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Christian Lück",
+            "email": "christian@clue.engineering"
+        }
+    ],
+    "require": {
+        "php": ">=5.3",
+        "clue/json-stream": "^0.1",
+        "react/event-loop": "^1.2",
+        "react/http": "^1.11",
+        "react/promise": "^3.2 || ^2.11 || ^1.3",
+        "react/promise-stream": "^1.6",
+        "react/socket": "^1.16",
+        "react/stream": "^1.4",
+        "rize/uri-template": "^0.3"
+    },
+    "require-dev": {
+        "clue/caret-notation": "^0.2",
+        "clue/tar-react": "^0.2",
+        "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+        "react/async": "^4.2 || ^3 || ^2"
+    },
+    "autoload": {
+        "psr-4": {
+            "Clue\\React\\Docker\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Clue\\Tests\\React\\Docker\\": "tests/"
+        }
+    }
 }

--- a/tests/FunctionalClientTest.php
+++ b/tests/FunctionalClientTest.php
@@ -478,11 +478,9 @@ class FunctionalClientTest extends TestCase
         $promise = $this->client->events($start, $end, array('network' => array($network['Id'])));
         $ret = \React\Async\await($promise);
 
-        // expects "create", "disconnect", "destroy" events ("connect" will be skipped because we don't start the container)
-        $this->assertCount(3, $ret);
+        $this->assertCount(2, $ret);
         $this->assertEquals('create', $ret[0]['Action']);
-        $this->assertEquals('disconnect', $ret[1]['Action']);
-        $this->assertEquals('destroy', $ret[2]['Action']);
+        $this->assertEquals('destroy', $ret[1]['Action']);
     }
 
     /**


### PR DESCRIPTION
This pull request updates the CI environment to use Ubuntu 24.04. Due to changes in container behavior in Ubuntu 24.04, only 2 container events are now generated instead of the previous 3, requiring minor adjustments to the test suite.
Builds on top of #89 and #88.

Initially planned to add PHP 8.4 support, but encountered the same dependency issue mentioned in https://github.com/clue/phar-composer/issues/137, specifically with the rize/uri-template package here.