### PR TITLE
Fix tests to support latest Docker version

### DIFF
--- a/tests/FunctionalClientTest.php
+++ b/tests/FunctionalClientTest.php
@@ -477,12 +477,21 @@ class FunctionalClientTest extends TestCase
         // get all events between starting and removing for this container
         $promise = $this->client->events($start, $end, array('network' => array($network['Id'])));
         $ret = \React\Async\await($promise);
+        assert(is_array($ret));
 
-        // expects "create", "disconnect", "destroy" events ("connect" will be skipped because we don't start the container)
-        $this->assertCount(3, $ret);
-        $this->assertEquals('create', $ret[0]['Action']);
-        $this->assertEquals('disconnect', $ret[1]['Action']);
-        $this->assertEquals('destroy', $ret[2]['Action']);
+        $actions = array(); // array_column($ret, 'Action'); // PHP 5.5+
+        foreach ($ret as $one) {
+            $actions[] = $one['Action'];
+        }
+
+        // expect 2 events as of ~2025, 3 in earlier versions
+        if (count($actions) === 2) {
+            // expects only "create" and "destroy" events (no "connect" / "disconnect" because we don't start the container)
+            $this->assertEquals(array('create', 'destroy'), $actions);
+        } else {
+            // expects "create", "disconnect", "destroy" events ("connect" will be skipped because we don't start the container)
+            $this->assertEquals(array('create', 'disconnect', 'destroy'), $actions);
+        }
     }
 
     /**


### PR DESCRIPTION
This changeset fixes the tests to support latest Docker version. Exact Docker Engine API version is unknown, but released some time around mid 2025, the changelogs weren't exactly helpful here. In either case, this fixes test compatibility with newer versions while also keeping support for earlier engine versions similar to how this was previously done in #80.

Builds on top of #80