### PR TITLE
Update test environment to fix tests on legacy PHP 7.2 with PHPUnit 8.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,7 @@ jobs:
           ini-file: development
       - run: composer install
       - run: docker pull busybox:latest
-      - run: vendor/bin/phpunit --coverage-text --coverage-clover=clover.xml
-        if: ${{ matrix.php >= 7.3 }}
-      - run: vendor/bin/phpunit --coverage-text --coverage-clover=clover.xml -c phpunit.xml.legacy
-        if: ${{ matrix.php < 7.3 }}
+      - run: vendor/bin/phpunit --coverage-text --coverage-clover=clover.xml ${{ matrix.php < 7.3 && '-c phpunit.xml.legacy' || '' }}
       - name: Check 100% code coverage
         shell: php {0}
         run: |

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "clue/caret-notation": "^0.2",
         "clue/tar-react": "^0.2",
-        "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+        "phpunit/phpunit": "^9.6 || ^8.5 || ^5.7 || ^4.8.36",
         "react/async": "^4.3 || ^3 || ^2"
     },
     "autoload": {


### PR DESCRIPTION
This changeset updates the test environment to fix tests on legacy PHP 7.2 with PHPUnit 8.5. This is needed to run the tests on legacy platforms due to recent upstream changes as discussed in https://github.com/clue/reactphp-redis/pull/180.

Builds on top of https://github.com/clue/reactphp-redis/pull/180 and #66 and others