### PR TITLE
Add condition parameter for containerWait

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -807,16 +807,18 @@ class Client
      * Block until container id stops, then returns the exit code
      *
      * @param string $container container ID
+     * @param string|null $condition (optional) Wait until a container state reaches the given condition
      * @return PromiseInterface Promise<array> `array('StatusCode' => 0)` (see link)
      * @link https://docs.docker.com/engine/api/v1.40/#operation/ContainerWait
      */
-    public function containerWait($container)
+    public function containerWait($container, $condition = null)
     {
         return $this->browser->post(
             $this->uri->expand(
-                'containers/{container}/wait',
+                'containers/{container}/wait{?condition}',
                 array(
-                    'container' => $container
+                    'container' => $container,
+                    'condition' => $condition
                 )
             )
         )->then(array($this->parser, 'expectJson'));

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -268,6 +268,14 @@ class ClientTest extends TestCase
         $this->expectPromiseResolveWith($json, $this->client->containerWait(123));
     }
 
+    public function testContainerWaitConditionalNextExit()
+    {
+        $json = array();
+        $this->expectRequestFlow('post', 'containers/123/wait?condition=next-exit', $this->createResponseJson($json), 'expectJson');
+
+        $this->expectPromiseResolveWith($json, $this->client->containerWait(123, 'next-exit'));
+    }
+
     public function testContainerKill()
     {
         $this->expectRequestFlow('post', 'containers/123/kill', $this->createResponse(), 'expectEmpty');


### PR DESCRIPTION
The `containerWait` https://docs.docker.com/reference/api/engine/version/v1.40/#tag/Container/operation/ContainerWait API supports a `condition` parameter which is not pass in the Client yet.
Add it as a method parameter and pass it if set.